### PR TITLE
Fix unassigned tickets breaking Issue view

### DIFF
--- a/app/views/issues/_related_zendesk_tickets.html.erb
+++ b/app/views/issues/_related_zendesk_tickets.html.erb
@@ -20,7 +20,11 @@
       <td class="id"><%= link_to ticket[:id], "https://#{@issue.zendesk_subdomain}.zendesk.com/agent/tickets/#{ticket[:id]}", target: '_blank' %>
       <td class="status"><%= ticket[:status] %></td>
       <td class="subject"><%= link_to ticket[:subject], "https://#{@issue.zendesk_subdomain}.zendesk.com/agent/tickets/#{ticket[:id]}", target: '_blank' %></td>
-      <td class="assignee_id"><%= mail_to ticket.assignee.email, ticket.assignee.name %></td>
+      <% if ticket.assignee.nil? %>
+      <td class="assignee_id"><%= ticket.group.name %></td>
+      <% else %>
+      <td class="assignee_id"><%= mail_to ticket.assignee.email, ticket.assignee.name, title: ticket.group.name %></td>
+      <% end %>
       <td class="created_at"><span title="<%= ticket[:created_at] %>"><%= ticket[:created_at].strftime('%m/%d/%Y') %></span></td>
       <td class="updated_at"><span title="<%= ticket[:updated_at] %>"><%= ticket[:updated_at].strftime('%m/%d/%Y') %></span></td>
     </tr>


### PR DESCRIPTION
In the event a ticket is assigned to a Group (unassigned from a user), the `ticket.assignee` is `nil`. Trying to get a property on `nil` is throws an error.
